### PR TITLE
Replace instances of `export {default}`

### DIFF
--- a/addon/models/current-practice-user.js
+++ b/addon/models/current-practice-user.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-auth/models/current-practice-user';
+import CurrentPracticeUser from 'ember-icis-auth/models/current-practice-user';
+
+export default CurrentPracticeUser;

--- a/app/adapters/issue.js
+++ b/app/adapters/issue.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/adapters/issue';
+import Issue from 'ember-icis-model/adapters/issue';
+
+export default Issue;

--- a/app/adapters/patient.js
+++ b/app/adapters/patient.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/adapters/patient';
+import Patient from 'ember-icis-model/adapters/patient';
+
+export default Patient;

--- a/app/models/current-practice-user.js
+++ b/app/models/current-practice-user.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/models/current-practice-user';
+import CurrentPracticeUser from 'ember-icis-model/models/current-practice-user';
+
+export default CurrentPracticeUser;

--- a/app/models/issue.js
+++ b/app/models/issue.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/models/issue';
+import Issue from 'ember-icis-model/models/issue';
+
+export default Issue;

--- a/app/models/note.js
+++ b/app/models/note.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/models/note';
+import Note from 'ember-icis-model/models/note';
+
+export default Note;

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/models/patient';
+import Patient from 'ember-icis-model/models/patient';
+
+export default Patient;

--- a/app/serializers/note.js
+++ b/app/serializers/note.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/serializers/note';
+import Note from 'ember-icis-model/serializers/note';
+
+export default Note;

--- a/app/serializers/patient.js
+++ b/app/serializers/patient.js
@@ -1,1 +1,3 @@
-export { default } from 'ember-icis-model/serializers/patient';
+import Patient from 'ember-icis-model/serializers/patient';
+
+export default Patient;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-model",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "All of ICIS's services in one handy model addon",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
The version of es6-module-transpiler that chirp includes cannot parse that syntax.

This makes no functional changes.