### PR TITLE
Fix initializer deprecation warning for >= ember 2.1.0

### DIFF
--- a/app/initializers/access-token-service.js
+++ b/app/initializers/access-token-service.js
@@ -1,6 +1,7 @@
 import AccessToken from 'ember-icis-model/services/access-token';
 
-export function initialize(container, application) {
+export function initialize() {
+  var application = arguments[1] || arguments[0];
   application.inject('adapter:note', 'accessTokenWrapper', 'service:access-token');
   application.inject('adapter:practice', 'accessTokenWrapper', 'service:access-token');
   application.inject('adapter:patient-autocomplete', 'accessTokenWrapper', 'service:access-token');


### PR DESCRIPTION
Initializers now only take 1 argument (see http://emberjs.com/deprecations/v2.x/#toc_initializer-arity). This commit is the suggested approach to support versions of Ember pre and post this change