### PR TITLE
Fix "null" patient nickname and middle_name

### DIFF
--- a/addon/models/patient-autocomplete.js
+++ b/addon/models/patient-autocomplete.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 export default DS.Model.extend({
   first_name: DS.attr('string'),
@@ -13,14 +14,22 @@ export default DS.Model.extend({
   }.property('dob'),
 
   fullName: function() {
-    var fullName = this.get('first_name');
-    if (this.get('nickname') !== "") {
-      fullName += ' "' + this.get('nickname') + '" ';
-    } else {
-      fullName += " ";
-    }
+    let nameParts = [];
+    [
+      'first_name', 'nickname',
+      'middle_name', 'last_name'
+    ].forEach((key) => {
+      const namePart = this.get(key);
+      if (Ember.isPresent(namePart)) {
+        if (key === 'nickname') {
+          nameParts.push(`"${namePart}"`);
+        } else {
+          nameParts.push(namePart);
+        }
+      }
+    });
 
-    fullName += this.get('middle_name') + " " + this.get('last_name') + " - " + this.get('prettyDob');
-    return fullName;
+    let fullName = nameParts.join(" ");
+    return `${fullName} - ${this.get('prettyDob')}`;
   }.property('first_name', 'last_name', 'nickname', 'middle_name', 'dob')
 });

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,13 @@
 {
   "name": "ember-icis-model",
   "dependencies": {
-    "ember": "1.13.5",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
+    "ember": "2.3.1",
+    "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.7",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
+    "ember-load-initializers": "0.1.6",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
+    "loader.js": "ember-cli/loader.js#3.2.1",
     "ember-mocha": "~0.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-model",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "All of ICIS's services in one handy model addon",
   "directories": {
     "doc": "doc",
@@ -22,21 +22,21 @@
   "license": "MIT",
   "devDependencies": {
     "bower": "^1.4.1",
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.6",
-    "ember-cli-app-version": "0.4.0",
+    "broccoli-asset-rev": "^2.1.2",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-mocha": "0.9.1",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-mocha": "^0.9.1",
     "ember-cli-moment": "0.0.1",
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.1",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.7",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "2.3.3",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-icis-auth": "^0.5.0",
@@ -46,7 +46,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.1.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-icis-model",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "All of ICIS's services in one handy model addon",
   "directories": {
     "doc": "doc",

--- a/tests/unit/models/patient-autocomplete-test.js
+++ b/tests/unit/models/patient-autocomplete-test.js
@@ -27,13 +27,61 @@ describeModel(
     describe("#fullName", function() {
       var model;
 
-      describe("has no nickname", function() {
+      describe("middle_name is empty string", function() {
+        beforeEach(function() {
+          model = this.subject({
+            first_name: "Gorbechev",
+            middle_name: "",
+            last_name: "Thunderhorse",
+            nickname: "Gorby",
+            prettyDob: "01/01/2000"
+          });
+        });
+
+        it("does not set the middle_name in the fullName", function() {
+          expect(model.get('fullName')).to.eq("Gorbechev \"Gorby\" Thunderhorse - 01/01/2000");
+        });
+      });
+
+      describe("middle_name is null", function() {
+        beforeEach(function() {
+          model = this.subject({
+            first_name: "Gorbechev",
+            middle_name: null,
+            last_name: "Thunderhorse",
+            nickname: "Gorby",
+            prettyDob: "01/01/2000"
+          });
+        });
+
+        it("does not set the middle_name in the fullName", function() {
+          expect(model.get('fullName')).to.eq("Gorbechev \"Gorby\" Thunderhorse - 01/01/2000");
+        });
+      });
+
+      describe("nickname is empty string", function() {
         beforeEach(function() {
           model = this.subject({
             first_name: "Gorbechev",
             middle_name: "Puff Puff",
             last_name: "Thunderhorse",
             nickname: "",
+            prettyDob: "01/01/2000"
+          });
+        });
+
+        it("does not set the nickname in the fullName", function() {
+          expect(model.get('fullName')).to.eq("Gorbechev Puff Puff Thunderhorse - 01/01/2000");
+        });
+      });
+
+      describe("nickname is null", function() {
+        beforeEach(function() {
+          model = this.subject({
+            first_name: "Gorbechev",
+            middle_name: "Puff Puff",
+            last_name: "Thunderhorse",
+            nickname: null,
             prettyDob: "01/01/2000"
           });
         });

--- a/tests/unit/serializers/note-test.js
+++ b/tests/unit/serializers/note-test.js
@@ -42,7 +42,7 @@ describeModel(
       var record = this.subject();
 
       Ember.run(function() {
-        var createdByUser = store.createRecord('currentPracticeUser',
+        var createdByUser = store.createRecord('staff-member',
                                                { id: 'someuserid' });
         record.set('createdBy', createdByUser);
       });


### PR DESCRIPTION
Some patients have `nickname` or `middle_name` set to `NULL` in the database. The `fullName` property in `patient-autocomplete` was only checking for empty string. This PR ensures that all empty (`null`, `""`, `undefined`) properties are omitted from the full name.

Also, updates the addon to using Ember 2.3, because I couldn't get the tests to run with Ember 1.13.x. Does not effect the runtime version (tested with Notes Dashboard and Scheduling). However, to be safe, this bumps the version to `0.5.0`